### PR TITLE
Add field Taken to Vehicule model

### DIFF
--- a/db/migrate/20211107171933_add_taken_to_vehicle.rb
+++ b/db/migrate/20211107171933_add_taken_to_vehicle.rb
@@ -1,0 +1,5 @@
+class AddTakenToVehicle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :vehicles, :taken, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_07_170815) do
+ActiveRecord::Schema.define(version: 2021_11_07_171933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2021_11_07_170815) do
   create_table "vehicles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "taken", default: false
     t.index ["id"], name: "index_vehicles_on_id", unique: true
   end
 


### PR DESCRIPTION
Adding the "taken" column to the vehicule model. So that, vehicules are not actually destroyed in our database, but more put in "sleep" mode when there is no ride